### PR TITLE
MS Edge doesn't support .apply on console.log

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,9 @@ Nanologger.prototype._print = function (level) {
     args.push(obj)
   })
 
-  console.log.apply(console, args)
+  // In IE/Edge console functions don't inherit from Function.prototype
+  // so this is necessary to get all the args applied.
+  Function.prototype.apply.apply(console.log, [console, args])
 }
 
 function color (color) {


### PR DESCRIPTION
The console functions don't use the Function prototype, so in order to make logging work correctly in ms edge we need to do this ridiculous construct to pass in the arguments.